### PR TITLE
Pin alpine to 3.23 and schedule CI every 2 weeks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   # run it manually
   workflow_dispatch:
+  # run every 2 weeks
+  schedule:
+    - cron: '0 0 1,15 * *'
 
 jobs:
   # define job to build and publish docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.23
 
 # Install Tor
 RUN apk add --no-cache tor curl && \


### PR DESCRIPTION
## Summary

- Pin base image from `alpine:edge` to `alpine:3.23` for reproducible builds
- Schedule CI to run automatically every 2 weeks (1st and 15th of each month)